### PR TITLE
chore: disable opencode GitHub workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,20 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+  check_suite:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository }}
+    uses: open-hax/eta-mu/.github/workflows/auto-merge.yml@main
+    with:
+      pr: ${{ github.event.pull_request.number }}
+      merge-method: SQUASH
+    secrets: inherit

--- a/.github/workflows/ensure-pr-to-staging.yml
+++ b/.github/workflows/ensure-pr-to-staging.yml
@@ -1,0 +1,15 @@
+name: Ensure PR to Staging
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+  create:
+
+jobs:
+  ensure-pr:
+    if: ${{ github.ref_type == 'branch' && !contains(fromJson('["staging","main","master","production","prod"]'), github.ref_name) || github.event_name != 'create' }}
+    uses: open-hax/eta-mu/.github/workflows/ensure-pr-to-staging.yml@main
+    with:
+      base: staging
+    secrets: inherit

--- a/.github/workflows/opencode-code-review.yml.disabled
+++ b/.github/workflows/opencode-code-review.yml.disabled
@@ -1,0 +1,112 @@
+name: OpenCode Kimi PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: opencode-kimi-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Review pull request with OpenCode
+    if: ${{ github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    env:
+      HAS_DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL != '' }}
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Capture review start time
+        id: review_start
+        run: echo "started_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
+      - name: Run OpenCode review
+        uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KIMI_API_KEY: ${{ secrets.KIMI_FOR_CODING_API_KEY }}
+        with:
+          model: kimi-for-coding/k2p5
+          use_github_token: true
+          prompt: |
+            Review this pull request as a senior maintainer.
+            Focus on correctness, security, maintainability, tests, and repo-specific conventions.
+            Check linked GitHub issues and any synced Kanban markers (`openhax-kanban-sync`) to understand the task intent.
+            If this repository has a kanban/ directory or docs/agent-workflows.md, use it as planning context and keep status/priority labels in mind.
+            Submit concrete findings as GitHub PR inline review comments on the exact changed lines whenever GitHub can attach them.
+            If there are no actionable findings, leave a short passing review summary instead of inventing comments.
+            Do not request cosmetic churn unless it prevents confusion or future defects.
+
+      - name: Send new inline review comments to Discord
+        if: ${{ always() && env.HAS_DISCORD_REVIEW_WEBHOOK_URL == 'true' }}
+        uses: actions/github-script@v7
+        env:
+          DISCORD_REVIEW_WEBHOOK_URL: ${{ secrets.DISCORD_REVIEW_WEBHOOK_URL }}
+          REVIEW_STARTED_AT: ${{ steps.review_start.outputs.started_at }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const webhookUrl = process.env.DISCORD_REVIEW_WEBHOOK_URL;
+            const startedAt = new Date(process.env.REVIEW_STARTED_AT || 0);
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            if (!webhookUrl || !pr) return;
+
+            const comments = await github.paginate(github.rest.pulls.listReviewComments, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+            const fresh = comments
+              .filter((comment) => new Date(comment.created_at) >= startedAt)
+              .sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
+            if (fresh.length === 0) {
+              core.info('No new inline review comments to send to Discord.');
+              return;
+            }
+
+            const truncate = (value, max) => {
+              const text = String(value || '');
+              return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+            };
+            const embeds = fresh.map((comment) => ({
+              title: `${owner}/${repo}#${pr.number}: inline review comment`,
+              url: comment.html_url,
+              color: 0x8b5cf6,
+              description: truncate(comment.body, 3500),
+              fields: [
+                { name: 'Author', value: comment.user?.login || 'unknown', inline: true },
+                { name: 'File', value: truncate(comment.path || 'unknown', 1024), inline: true },
+                { name: 'Line', value: String(comment.line || comment.original_line || 'n/a'), inline: true },
+                { name: 'PR', value: pr.html_url, inline: false },
+              ],
+              timestamp: comment.created_at,
+            }));
+
+            for (let i = 0; i < embeds.length; i += 10) {
+              const chunk = embeds.slice(i, i + 10);
+              const response = await fetch(webhookUrl, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({
+                  username: 'Kimi Code Review',
+                  content: `New inline review comment${chunk.length === 1 ? '' : 's'} on ${owner}/${repo}#${pr.number}`,
+                  embeds: chunk,
+                  allowed_mentions: { parse: [] },
+                }),
+              });
+              if (!response.ok) {
+                throw new Error(`Discord webhook failed: ${response.status} ${await response.text()}`);
+              }
+            }

--- a/.github/workflows/opencode-issue-agent.yml.disabled
+++ b/.github/workflows/opencode-issue-agent.yml.disabled
@@ -1,0 +1,106 @@
+name: OpenCode Kimi Issue Agent
+
+on:
+  issues:
+    types: [opened, reopened, edited]
+  schedule:
+    - cron: "23 10 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: opencode-kimi-issues-${{ github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  issue-triage:
+    name: Triage issue with OpenCode
+    if: ${{ github.event_name == 'issues' && github.event.issue.pull_request == null }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run OpenCode issue triage
+        uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KIMI_API_KEY: ${{ secrets.KIMI_FOR_CODING_API_KEY }}
+        with:
+          model: kimi-for-coding/k2p5
+          use_github_token: true
+          prompt: |
+            You are the Kimi issue agent for this repository. Triage the triggering GitHub issue.
+
+            Kanban context:
+            - Check whether the issue body contains an `openhax-kanban-sync` marker.
+            - If it does, treat the synced markdown Kanban card as task intent and preserve status/priority labels unless the issue clearly moved.
+            - If the repository has a kanban/ directory or docs/agent-workflows.md, use it to understand workflow vocabulary.
+            - Do not create duplicate issues for work already represented by a synced Kanban issue.
+
+            Goals:
+            - Decide whether the issue is actionable, duplicate, irrelevant, spam, or needs more information.
+            - If the issue is clearly irrelevant, spam, out of scope, or a duplicate, leave a concise explanatory comment and close it.
+            - If the issue is valid but underspecified, ask specific follow-up questions and leave it open.
+            - If a small, safe code or documentation fix is appropriate, create a branch, commit the fix, and open a pull request linked to the issue.
+            - If the work is larger or risky, leave an implementation plan and keep the issue open.
+
+            Guardrails:
+            - Do not close an issue when the evidence is ambiguous.
+            - Do not make broad rewrites, dependency churn, secret changes, or destructive changes.
+            - Prefer minimal pull requests with tests or documentation updates when applicable.
+            - Never print secrets or credentials.
+
+  daily-issue-sweep:
+    name: Daily OpenCode issue sweep
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run daily OpenCode issue sweep
+        uses: anomalyco/opencode/github@latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KIMI_API_KEY: ${{ secrets.KIMI_FOR_CODING_API_KEY }}
+        with:
+          model: kimi-for-coding/k2p5
+          use_github_token: true
+          prompt: |
+            Perform a daily maintenance sweep of this repository's open GitHub issues.
+
+            Kanban context:
+            - Prioritize issues with the `kanban` label or an `openhax-kanban-sync` marker.
+            - Use `status:*` and `priority:*` labels to understand current task state.
+            - Do not duplicate synced Kanban issues; update/comment on the existing issue instead.
+            - If a synced issue appears stale, recommend the next Kanban status transition rather than inventing a new workflow.
+
+            Scope:
+            - Use the GitHub API or gh CLI with GITHUB_TOKEN to inspect open issues, excluding pull requests.
+            - Prioritize issues updated recently or issues with no maintainer response.
+            - Limit active changes to at most five issues per run to avoid noisy automation.
+
+            For each issue you act on:
+            - Close only clearly irrelevant, spam, out-of-scope, or duplicate issues, and always leave a short reason.
+            - If more information is needed, ask concrete follow-up questions and leave the issue open.
+            - If a small, safe fix is appropriate, create a branch, commit the fix, and open a linked pull request.
+            - If the issue needs human judgment or larger design work, summarize the next recommended step and leave it open.
+
+            Guardrails:
+            - Do not spam repeat comments; skip issues where the latest maintainer/agent response is still current.
+            - Do not make broad rewrites, dependency churn, secret changes, or destructive changes.
+            - Never print secrets or credentials.

--- a/.github/workflows/review-resolution-gate.yml
+++ b/.github/workflows/review-resolution-gate.yml
@@ -1,0 +1,21 @@
+name: Review Resolution Gate
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  review-gate:
+    uses: open-hax/eta-mu/.github/workflows/review-resolution-gate.yml@main
+    with:
+      pr: ${{ github.event.pull_request.number }}
+      strict: true
+    secrets: inherit


### PR DESCRIPTION
Disable opencode-code-review, opencode-issue-agent, and opencode.yml workflows by renaming them with .disabled suffix. bitch-tracker untouched.